### PR TITLE
Allow for newer versions of Ruby of the 2.3.x branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "2.3.0"
+ruby '~> 2.3.0'
 gem 'rails', '~> 3.2.22'
 
 # gem 'dotenv-rails', groups: [:development, :test]


### PR DESCRIPTION
This allows the application to work with latest versions of the Ruby Buildpack. Tested with versions 1.6.34 and 1.6.42